### PR TITLE
Modified Calculation of the p-value threshold for Significance Testing

### DIFF
--- a/mEBA_CPPfunctions.cpp
+++ b/mEBA_CPPfunctions.cpp
@@ -139,7 +139,7 @@ Rcpp::List msboot(int nrep, arma::mat x, int Wsel, bool stdz, int ncore){
       uvec srtidx = sort_index(dfobs,"descend"); //ordering of largest test stats
       
       //bonferroni correction for candidate testing points
-      double thr = 0.05/accu(freqcand);
+      double thr = 0.05/accu(freqcand.col(1));
       
       int stp=0;
       while(stp==0){


### PR DESCRIPTION
Here, I modified how the threshold for testing if frequencies are significant partition points is calculated- to make it more accurate. 